### PR TITLE
Support non-Windows configure and build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,7 @@ option(enable-lazy-lock "Enable lazy locking (only lock when multi-threaded" OFF
 option(force_lazy_lock "Forcing lazy-lock to avoid allocator/threading bootstrap issues" OFF)
 # install_prefix - installation directory prefix
 # with-xslroot=<path>  XSL stylesheet root path
+option(disable-zone-allocator "Disable zone allocator for Darwin" ON)
 
 set (PACKAGE_NAME "jemalloc")
 project (${PACKAGE_NAME} C)
@@ -204,7 +205,7 @@ set(abi "elf")
 
 # Whether malloc_usable_size definition can use const argument
 CHECK_INCLUDE_FILES (malloc.h HAVE_MALLOC_H)
-if(HAVE_MALLOC_H)
+if(HAVE_MALLOC_H OR APPLE)
     set(JEMALLOC_USABLE_SIZE_CONST const)
 endif()    
 
@@ -702,7 +703,7 @@ set(C_SRCS
   src/witness.c
 )
 
-if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
+if(CMAKE_SYSTEM_NAME MATCHES "Darwin" AND NOT disable-zone-allocator)
   list(APPEND C_SRCS src/zone.c)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -491,6 +491,7 @@ if(NOT WIN32)
     set(JEMALLOC_HAVE_SYSCALL 1)
   endif()
 
+  include(CheckFunctionExists)
   CHECK_FUNCTION_EXISTS(secure_getenv HAVE_SECURE_GETENV)
   if(HAVE_SECURE_GETENV)
     set(JEMALLOC_HAVE_SECURE_GETENV 1)

--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -988,7 +988,7 @@ malloc_conf_init(void)
 			int saved_errno = errno;
 			const char *linkname =
 #  ifdef JEMALLOC_PREFIX
-			    "/etc/"JEMALLOC_PREFIX"malloc.conf"
+			    "/etc/JEMALLOC_PREFIXmalloc.conf"
 #  else
 			    "/etc/malloc.conf"
 #  endif


### PR DESCRIPTION
The current cmake code is full of WIN32 only code, improve these to support non-Windows.